### PR TITLE
Fix vectorAngle magnitude bug

### DIFF
--- a/src/modules/geometry.js
+++ b/src/modules/geometry.js
@@ -277,7 +277,7 @@ const approxUnitArc = function approxUnitArc(ang1, ang2) {
 const vectorAngle = function vectorAngle(ux, uy, vx, vy) {
     const sign = ux * vy - uy * vx < 0 ? -1 : 1;
     const umag = sqrt(ux * ux + uy * uy);
-    const vmag = sqrt(ux * ux + uy * uy);
+    const vmag = sqrt(vx * vx + vy * vy);
     const dot = ux * vx + uy * vy;
     let div = dot / (umag * vmag);
 


### PR DESCRIPTION
## Summary
- correct vector magnitude in `vectorAngle` function

## Testing
- `npm run lint` *(fails: ESLint couldn't find config)*

------
https://chatgpt.com/codex/tasks/task_e_6842613af96c8329bad9772e9f818411