### PR TITLE
Improve logging for canvas renderer

### DIFF
--- a/src/modules/chain.js
+++ b/src/modules/chain.js
@@ -2,6 +2,7 @@
 // import { queue, ease } from './'
 import queue from "./queue.js";
 import ease from "./ease.js";
+import logger from "./logger.js";
 
 let Id = 0;
 let chainId = 0;
@@ -364,7 +365,7 @@ ParallelGroup.prototype.triggerChild = function PGtriggerChild(exe) {
     } else if (typeof exe === "function") {
         exe();
     } else {
-        console.log("wrong type");
+        logger.warn("wrong type");
     }
 };
 

--- a/src/modules/coreApi.js
+++ b/src/modules/coreApi.js
@@ -4,6 +4,7 @@ import geometry from "./geometry.js";
 import queue from "./queue.js";
 import ease from "./ease.js";
 import colorMap from "./colorMap.js";
+import logger from "./logger.js";
 import { ResizeObserver as resizePolyfill } from "@juggle/resize-observer";
 import { canvasStyleMapper, svgStyleMapper } from "./constants.js";
 
@@ -137,9 +138,7 @@ const animate = function animate(self, fromConfig, targetConfig) {
                 } else {
                     if (key === "d") {
                         self.morphTo(targetConfig);
-                    } else if (key === "points") {
-                        console.log("write points mapper");
-                    } else {
+                    } else if (key !== "points") {
                         runStack[runStack.length] = attrTransition(
                             self,
                             key,
@@ -345,7 +344,7 @@ NodePrototype.prototype.getStyle = function (_) {
 
 NodePrototype.prototype.exec = function Cexe(exe) {
     if (typeof exe !== "function") {
-        console.error("Wrong Exe type");
+        logger.error("Wrong Exe type");
     }
 
     exe.call(this, this.dataObj);

--- a/src/modules/geometry.js
+++ b/src/modules/geometry.js
@@ -8,6 +8,7 @@ const tan = Math.tan;
 const PI = Math.PI;
 const ceil = Math.ceil;
 const max = Math.max;
+import logger from "./logger.js";
 
 function pw(a, x) {
     let val = 1;
@@ -163,7 +164,7 @@ function toCubicCurves(stack) {
                 length: _[i].length,
             });
         } else {
-            console.log("wrong cmd type");
+            logger.warn("wrong cmd type");
         }
     }
 
@@ -219,7 +220,7 @@ const _slicedToArray = (function () {
                 if (!_n && _i.return) _i.return();
             } finally {
                 if (_d) {
-                    console.log("Error -" + _e);
+                    logger.error("Error -" + _e);
                 }
             }
         }

--- a/src/modules/logger.js
+++ b/src/modules/logger.js
@@ -1,0 +1,14 @@
+/* eslint-disable no-console */
+const logger = {
+    info: function () {
+        console.info.apply(console, arguments);
+    },
+    warn: function () {
+        console.warn.apply(console, arguments);
+    },
+    error: function () {
+        console.error.apply(console, arguments);
+    },
+};
+
+export default logger;

--- a/src/modules/path.js
+++ b/src/modules/path.js
@@ -1250,8 +1250,6 @@ function AnimatePathTo(targetConfig, fromConfig) {
                 length: 0,
             });
             totalLength += 0;
-        } else {
-            // console.log('M Or Other Type')
         }
     }
 

--- a/src/modules/queue.js
+++ b/src/modules/queue.js
@@ -1,4 +1,5 @@
 /* eslint-disable no-undef */
+import logger from "./logger.js";
 let animatorInstance = null;
 let tweens = [];
 const vDoms = {};
@@ -249,7 +250,7 @@ function exeFrameCaller() {
         animatorInstance.vDomUpdates();
 
     } catch (err) {
-        console.error(err);
+        logger.error(err);
     } finally {
         animeFrameId = window.requestAnimationFrame(exeFrameCaller);
     }

--- a/src/modules/renderers/canvas.js
+++ b/src/modules/renderers/canvas.js
@@ -6,6 +6,7 @@ import colorMap from "./../colorMap.js";
 import Events from "./../events.js";
 import behaviour from "./../behaviour.js";
 import { canvasStyleMapper, pdfSupportedFontFamily } from "./../constants.js";
+import logger from "../logger.js";
 
 import {
     NodePrototype,
@@ -325,7 +326,7 @@ CanvasGradient.prototype.exe = function GRAexe(ctx, BBox) {
     } else if (this.type === "radial" && this.mode === "absolute") {
         return this.absoluteRadialGradient(ctx);
     } else {
-        console.error("wrong Gradiant type");
+        logger.error("wrong Gradiant type");
     }
 };
 
@@ -343,7 +344,7 @@ CanvasGradient.prototype.exePdf = function GRAexe(ctx, BBox, AABox) {
     } else if (this.type === "radial" && this.mode === "absolute") {
         return this.absoluteRadialGradientPdf(ctx, AABox);
     } else {
-        console.error("wrong Gradiant type");
+        logger.error("wrong Gradiant type");
     }
 };
 
@@ -1084,7 +1085,7 @@ RenderText.prototype.executePdf = function RTexecute(pdfCtx, block) {
             try {
                 pdfCtx.font(fontFamily);
             } catch (err) {
-                console.error(`Unknown font family - ${fontFamily}`);
+                logger.error(`Unknown font family - ${fontFamily}`);
             }
         }
     }
@@ -1512,7 +1513,7 @@ RenderPath.prototype.in = function RPinfun(co) {
 
 function polygonExe(points) {
     if (Object.prototype.toString.call(points) !== "[object Array]") {
-        console.error("Points expected as array [{x: , y:}]");
+        logger.error("Points expected as array [{x: , y:}]");
         return;
     }
     if (points && points.length === 0) {
@@ -1886,7 +1887,7 @@ RenderGroup.prototype.child = function RGchild(obj) {
             self.stack[self.stack.length] = d;
         });
     } else {
-        console.log("wrong Object");
+        logger.warn("wrong Object");
     }
 };
 
@@ -2020,7 +2021,7 @@ CanvasNodeExe.prototype.stylesExe = function CstylesExe() {
                 value = value.exe(ctx, dom.BBox);
             }
         } else if (typeof value !== 'string' && typeof value !== 'number') {
-            console.log("Unknown Style");
+            logger.warn("Unknown Style");
             continue;
         }
 
@@ -2057,7 +2058,7 @@ CanvasNodeExe.prototype.stylesExePdf = function CstylesExe(pdfCtx) {
             style[key] = style[key].call(this, this.dataObj);
             value = style[key];
         } else {
-            console.log("unkonwn Style");
+            logger.warn("unkonwn Style");
         }
 
         if (pdfStyleMapper[key]) {
@@ -2078,7 +2079,7 @@ CanvasNodeExe.prototype.stylesExePdf = function CstylesExe(pdfCtx) {
         } else if (typeof pdfCtx[key] === "function") {
             pdfCtx[key](value);
         } else {
-            console.log("junk comp");
+            logger.warn("junk comp");
         }
     }
 };
@@ -2200,7 +2201,7 @@ CanvasNodeExe.prototype.prependChild = function child(childrens) {
             self.children.unshift(childrensLocal[i]);
         }
     } else {
-        console.error("Trying to insert child to nonGroup Element");
+        logger.error("Trying to insert child to nonGroup Element");
     }
 
     return self;
@@ -2217,7 +2218,7 @@ CanvasNodeExe.prototype.child = function child(childrens) {
             self.children[self.children.length] = childrensLocal[i];
         }
     } else {
-        console.error("Trying to insert child to nonGroup Element");
+        logger.error("Trying to insert child to nonGroup Element");
     }
 
     return self;
@@ -2463,7 +2464,7 @@ function textureImageInstance(self, url) {
     };
 
     imageIns.onerror = function onerror(error) {
-        console.error(error);
+        logger.error(error);
         if (self.nodeExe.attr.onerror && typeof self.nodeExe.attr.onerror === "function") {
             self.nodeExe.attr.onerror.call(self.nodeExe, error);
         }
@@ -2796,7 +2797,7 @@ function createPage(ctx, vDomIndex) {
             posY = 0;
 
             if (!text || elHeight <= 0) {
-                console.warn("Invalid text or element height.");
+                logger.warn("Invalid text or element height.");
                 return 0;
             }
 
@@ -2806,7 +2807,7 @@ function createPage(ctx, vDomIndex) {
                 const index = Math.floor(text.length * percent);
 
                 if (index <= prevIndex) {
-                    console.warn("Text splitting encountered an infinite loop.");
+                    logger.warn("Text splitting encountered an infinite loop.");
                     break;
                 }
 

--- a/src/modules/renderers/pdf.js
+++ b/src/modules/renderers/pdf.js
@@ -7,6 +7,7 @@ import fs from "fs";
 import { STANDARD_FONTS } from "./../../data/static-fonts.js";
 import { createPage, CanvasNodeExe } from "./canvas.js";
 import { pdfSupportedFontFamily } from "./../constants.js";
+import logger from "../logger.js";
 
 if (Object.keys(STANDARD_FONTS).length > 0) {
     for(let key in STANDARD_FONTS) {
@@ -191,7 +192,7 @@ function PDFCreator(config) {
             });
         }
         catch (err) {
-            console.error(err);
+            logger.error(err);
         }
     };
 
@@ -347,7 +348,7 @@ async function registerFontFromConfig(doc, fontRegister = {}) {
         }
         return true;
     } catch (err) {
-        console.error(err);
+        logger.error(err);
         throw new Error('Font registration failed');
     }
 }

--- a/src/modules/renderers/svg.js
+++ b/src/modules/renderers/svg.js
@@ -3,6 +3,7 @@ import VDom from "./../VDom.js";
 import { CheckPathType, AnimatePathTo, MorphTo} from "./../path.js";
 import colorMap from "./../colorMap.js";
 import Events from "./../events.js";
+import logger from "../logger.js";
 import {
     CollectionPrototype,
     NodePrototype,
@@ -598,7 +599,7 @@ DomExe.prototype.child = function DMchild(nodes) {
         nodes.parentNode = self;
         this.children.push(nodes);
     } else {
-        console.log("wrong node type");
+        logger.warn("wrong node type");
     }
 
     return this;

--- a/src/modules/renderers/webgl.js
+++ b/src/modules/renderers/webgl.js
@@ -7,6 +7,7 @@ import shaders from "./../shaders.js";
 import earcut from "earcut";
 import Events from "./../events.js";
 import behaviour from "./../behaviour.js";
+import logger from "../logger.js";
 import {
     CollectionPrototype,
     NodePrototype,
@@ -297,7 +298,7 @@ function loadShader(ctx, shaderSource, shaderType) {
 
     if (!compiled) {
         var lastError = ctx.getShaderInfoLog(shader);
-        console.error("*** Error compiling shader '" + shader + "':" + lastError);
+        logger.error("*** Error compiling shader '" + shader + "':" + lastError);
         ctx.deleteShader(shader);
         return null;
     }
@@ -315,7 +316,7 @@ function createProgram(ctx, shaders) {
 
     if (!linked) {
         var lastError = ctx.getProgramInfoLog(program);
-        console.error("Error in program linking:" + lastError);
+        logger.error("Error in program linking:" + lastError);
         ctx.deleteProgram(program);
         return null;
     }
@@ -348,7 +349,7 @@ function WebglDom() {
 
 WebglDom.prototype.exec = function (exe, d) {
     if (typeof exe !== "function") {
-        console.error("Wrong Exe type");
+        logger.error("Wrong Exe type");
     }
 
     exe.call(this, d);
@@ -1714,7 +1715,7 @@ function webGlUniformMapper(ctx, program, uniform, uniObj) {
         if (Number.isInteger(Math.sqrt(uniObj.value.length))) {
             type = "uniformMatrix" + Math.sqrt(uniObj.value.length) + "fv";
         } else {
-            console.error("Not Square Matrix");
+            logger.error("Not Square Matrix");
         }
     }
 
@@ -1768,7 +1769,7 @@ function RenderWebglShader(ctx, shader, vDomIndex) {
             this.attributes = this.geometry.attributes;
             this.indexes = this.geometry.indexes;
         } else {
-            console.error("Wrong Geometry type");
+            logger.error("Wrong Geometry type");
         }
     }
 
@@ -2084,7 +2085,7 @@ function updateVertex(self, index, length, ver) {
     const b = index * length * 2;
     let i = 0;
     if (isNaN(positionArray[b])) {
-        console.log("overriding Nan");
+        logger.warn("overriding NaN in vertex data");
     }
     while (i < ver.length) {
         positionArray[b + i] = ver[i];
@@ -2156,7 +2157,7 @@ function updateColor(self, index, length, fillStyle) {
     const colorArray = self.addColor_ ? self.colorArray : self.typedColorArray;
     const ti = index * length * 4;
     if (isNaN(colorArray[ti])) {
-        console.log("overriding Nan");
+        logger.warn("overriding NaN in color data");
     }
     const b = index * length * 4;
     let i = 0;
@@ -2174,7 +2175,7 @@ function clearColor(self, index, length) {
     const colorArray = self.addColor_ ? self.colorArray : self.typedColorArray;
     const ti = index * length * 4;
     if (isNaN(colorArray[ti])) {
-        console.log("overriding Nan");
+        logger.warn("overriding NaN in color data");
     }
     const b = index * length * 4;
     let i = 0;
@@ -3209,7 +3210,7 @@ WebglNodeExe.prototype.child = function child(childrens) {
                     if (node.el === this.dom.shader.attr.shaderType) {
                         node.dom.setShader(this.dom.shader);
                     } else {
-                        console.warn(
+                        logger.warn(
                             "wrong el type '" +
                                 node.el +
                                 "' being added to shader group - '" +
@@ -3248,7 +3249,7 @@ WebglNodeExe.prototype.child = function child(childrens) {
             }
         }
     } else {
-        console.log("Error");
+        logger.error("Error adding node to group");
     }
 
     this.BBoxUpdate = true;
@@ -3821,7 +3822,7 @@ TextureObject.prototype.update = function () {
 
     if (this.mipMap) {
         if (!isPowerOf2(self.image.width) || !isPowerOf2(self.image.height)) {
-            console.warn("Image dimension not in power of 2");
+            logger.warn("Image dimension not in power of 2");
         }
         ctx.generateMipmap(ctx.TEXTURE_2D);
         ctx.texParameteri(ctx.TEXTURE_2D, ctx.TEXTURE_MIN_FILTER, ctx[this.minFilter]);


### PR DESCRIPTION
## Summary
- add a simple logger utility
- switch canvas renderer console calls to use the logger
- replace console usage across modules with logger
- remove stray debug log in path module

## Testing
- `npm run lint` *(fails: ESLint couldn't find a config)*

------
https://chatgpt.com/codex/tasks/task_e_6842643c42d08329b295a6cd056c3bcf