### PR TITLE
Fix svg deletion recursion and adjust viewBox parameters

### DIFF
--- a/src/modules/renderers/svg.js
+++ b/src/modules/renderers/svg.js
@@ -759,10 +759,8 @@ DomExe.prototype.removeChild = function DMremoveChild(obj) {
 
 function markForDeletion(removedNode) {
     removedNode.deleted = true;
-    if (!removedNode.deleted) {
-        for(let i = 0; i < removedNode.children.length; i++) {
-            markForDeletion(removedNode[i]);
-        }
+    for (let i = 0; i < removedNode.children.length; i++) {
+        markForDeletion(removedNode.children[i]);
     }
 }
 
@@ -849,20 +847,26 @@ function svgLayer(container, layerSettings = {}) {
     };
 
     root.setSize = function (width, height) {
-        this.dom.setAttribute("height", height);
-        this.dom.setAttribute("width", width);
-        this.width = width;
-        this.height = height;
-        cHeight = height;
-        cWidth = width;
+        if (this.width !== width || this.height !== height) {
+            this.dom.setAttribute("height", height);
+            this.dom.setAttribute("width", width);
+            this.width = width;
+            this.height = height;
+            cHeight = height;
+            cWidth = width;
+        }
     };
 
     root.update = function () {
         this.execute();
     };
 
-    root.setViewBox = function (x, y, height, width) {
-        this.dom.setAttribute("viewBox", x + "," + y + "," + width + "," + height);
+    root.setViewBox = function (x, y, width, height) {
+        const vb = `${x},${y},${width},${height}`;
+        if (this._viewBox !== vb) {
+            this.dom.setAttribute("viewBox", vb);
+            this._viewBox = vb;
+        }
     };
 
     root.destroy = function () {


### PR DESCRIPTION
## Summary
- ensure recursive deletion of SVG nodes
- correct `setViewBox` parameter order
- avoid redundant updates to SVG size and viewBox attributes

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68426d23d9f483299e878557a9e644ad