### PR TITLE
Use index loops for large collections

### DIFF
--- a/src/modules/VDom.js
+++ b/src/modules/VDom.js
@@ -23,9 +23,9 @@ VDom.prototype.eventsCheck = function eventsCheck(nodes, mouseCoor, rawEvent) {
     const self = this;
     let node, temp;
 
-    for (var i = 0; i <= nodes.length - 1; i += 1) {
-        var d = nodes[i];
-        var coOr = {
+    for (let i = 0; i < nodes.length; i += 1) {
+        const d = nodes[i];
+        const coOr = {
             x: mouseCoor.x,
             y: mouseCoor.y,
         };

--- a/src/modules/behaviour.js
+++ b/src/modules/behaviour.js
@@ -341,7 +341,7 @@ ZoomClass.prototype.zoomPinch = function (trgt, event, eventsInstance) {
             this.onZoomStart(trgt, event, eventsInstance);
         } else {
             const distance_ = this.event.distance;
-            for (var i = 0; i < pointers.length; i++) {
+            for (let i = 0; i < pointers.length; i += 1) {
                 if (event.pointerId === pointers[i].pointerId) {
                     pointers[i] = event;
                     break;

--- a/src/modules/events.js
+++ b/src/modules/events.js
@@ -17,7 +17,7 @@ Events.prototype.removePointer = function (e) {
     const self = this;
     const pointers = this.pointers;
     let index = -1;
-    for (var i = 0; i < pointers.length; i++) {
+    for (let i = 0; i < pointers.length; i += 1) {
         if (e.pointerId === pointers[i].pointerId) {
             index = i;
             break;
@@ -376,9 +376,9 @@ Events.prototype.wheelEventCheck = function (e) {
 function propogateEvent(nodes, mouseCoor, rawEvent, eventType) {
     let node, temp;
 
-    for (var i = nodes.length - 1; i >= 0; i -= 1) {
-        var d = nodes[i];
-        var coOr = {
+    for (let i = nodes.length - 1; i >= 0; i -= 1) {
+        const d = nodes[i];
+        const coOr = {
             x: mouseCoor.x,
             y: mouseCoor.y,
         };

--- a/src/modules/path.js
+++ b/src/modules/path.js
@@ -560,17 +560,17 @@ Path.prototype.points = function (points) {
 
     this.m(true, { x: points[0].x, y: points[0].y });
 
-    var m = 0;
-    var dx1 = 0;
-    var dy1 = 0;
+    let m = 0;
+    let dx1 = 0;
+    let dy1 = 0;
     let dx2 = 0;
     let dy2 = 0;
 
-    var preP = points[0];
+    let preP = points[0];
 
-    for (var i = 1; i < points.length; i++) {
-        var curP = points[i];
-        var nexP = points[i + 1];
+    for (let i = 1; i < points.length; i++) {
+        const curP = points[i];
+        const nexP = points[i + 1];
         dx2 = 0;
         dy2 = 0;
         if (nexP) {

--- a/src/modules/renderers/canvas.js
+++ b/src/modules/renderers/canvas.js
@@ -1033,10 +1033,11 @@ RenderText.prototype.updateBBox = function RTupdateBBox() {
 RenderText.prototype.execute = function RTexecute() {
     if (this.attr.text !== undefined && this.attr.text !== null) {
         if (this.textList && this.textList.length > 0) {
-            for (var i = 0; i < this.textList.length; i++) {
+            for (let i = 0; i < this.textList.length; i += 1) {
+                const text = this.textList[i];
                 if (this.ctx.fillStyle !== "#000000") {
                     this.ctx.fillText(
-                        this.textList[i],
+                        text,
                         this.attr.x,
                         this.attr.y + this.textHeight * (i + 1)
                     );
@@ -1044,7 +1045,7 @@ RenderText.prototype.execute = function RTexecute() {
 
                 if (this.ctx.strokeStyle !== "#000000") {
                     this.ctx.strokeText(
-                        this.textList[i],
+                        text,
                         this.attr.x,
                         this.attr.y + this.textHeight * (i + 1)
                     );
@@ -1317,7 +1318,7 @@ RenderPolyline.prototype.execute = function polylineExe() {
     if (!this.attr.points || this.attr.points.length === 0) return;
     this.ctx.beginPath();
     self.ctx.moveTo(this.attr.points[0].x, this.attr.points[0].y);
-    for (var i = 1; i < this.attr.points.length; i++) {
+    for (let i = 1; i < this.attr.points.length; i++) {
         d = this.attr.points[i];
         self.ctx.lineTo(d.x, d.y);
     }
@@ -1333,7 +1334,7 @@ RenderPolyline.prototype.executePdf = function polylineExe(pdfCtx, block) {
     }
 
     pdfCtx.moveTo(this.attr.points[0].x, this.attr.points[0].y);
-    for (var i = 1; i < this.attr.points.length; i++) {
+    for (let i = 1; i < this.attr.points.length; i++) {
         d = this.attr.points[i];
         pdfCtx.lineTo(d.x, d.y);
     }

--- a/src/modules/renderers/webgl.js
+++ b/src/modules/renderers/webgl.js
@@ -3040,7 +3040,7 @@ WebglNodeExe.prototype.reIndexChildren = function (shader) {
     children = children.filter(function (d) {
         return d;
     });
-    for (var i = 0, len = children.length; i < len; i++) {
+    for (let i = 0, len = children.length; i < len; i += 1) {
         children[i].dom.pindex = i;
     }
 


### PR DESCRIPTION
## Summary
- revert to index-based iteration in VDom events handling
- iterate pointers with classic loops in behaviour and event modules
- loop through text nodes in canvas renderer using indices

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6842816001008329846dc3f2dd9c3e73